### PR TITLE
Build for macos update

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ On Debian based systems you can run (**apt** can by replaced with **apt-get** or
  - sdl2_ttf
  - sdl2_image
 
-`brew install sdl2 sdl_ttf sdl2_image`
+`brew install sdl2 sdl2_ttf sdl2_image`
 
 #### Compilation
 


### PR DESCRIPTION
fixing fatal error: 'SDL2/SDL_ttf.h' file not found. Because sdl_ttf runs with sdl1 not run with sdl 2 anymore. Update sdl_ttf to sdl2_ttf.